### PR TITLE
Change markdown engine from rdiscount to redcarpet

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 # Dependencies
-markdown:         rdiscount
+markdown:         redcarpet
 pygments:         true
 
 # Permalinks


### PR DESCRIPTION
As discussed with regards to mdo/hyde here is the pull request for switching the markdown engine
from rdiscount to redcarpet. However now that the repos have moved I'm not sure which you
want me to submit this to so I'm submitting it to all the things, accept or deny as desired.
