### PR TITLE
Add margin under lead copy and limit image width to container

### DIFF
--- a/public/css/poole.css
+++ b/public/css/poole.css
@@ -202,9 +202,9 @@ blockquote p:last-child {
 
 img {
   display: block;
+  max-width: 100%;
   margin: 0 0 1rem;
   border-radius: 5px;
-  max-width: 100%; !important
 }
 
 /* Tables */
@@ -234,7 +234,6 @@ tbody tr:nth-child(odd) th {
 .lead {
   font-size: 1.25rem;
   font-weight: 300;
-  margin-bottom: 1rem;
 }
 
 


### PR DESCRIPTION
I've just started to tweak lanyon for my personal site, and noticed a the following tweaks to poole that I think will benefit everyone. Please consider this patch.
