### PR TITLE
Fix 404 URL

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: "404: Page not found"
+permalink: /404.html
 ---
 
 <div class="page">


### PR DESCRIPTION
Fix for issue #4.

Setting permalink to /404.html allows GitHub Pages to use it as a custom 404 page.
