### PR TITLE
Points the jekyll links to the new location

### DIFF
--- a/_posts/2013-12-31-whats-jekyll.md
+++ b/_posts/2013-12-31-whats-jekyll.md
@@ -3,10 +3,10 @@ layout: post
 title: What's Jekyll?
 ---
 
-[Jekyll](http://jekyllrb.com) is a static site generator, an open-source tool for creating simple yet powerful websites of all shapes and sizes. From [the project's readme](https://github.com/mojombo/jekyll/blob/master/README.markdown):
+[Jekyll](http://jekyllrb.com) is a static site generator, an open-source tool for creating simple yet powerful websites of all shapes and sizes. From [the project's readme](https://github.com/jekyll/jekyll/blob/master/README.markdown):
 
   > Jekyll is a simple, blog aware, static site generator. It takes a template directory [...] and spits out a complete, static website suitable for serving with Apache or your favorite web server. This is also the engine behind GitHub Pages, which you can use to host your project’s page or blog right here from GitHub.
 
 It's an immensely useful tool and one we encourage you to use here with Hyde.
 
-Find out more by [visiting the project on GitHub](https://github.com/mojombo/jekyll).
+Find out more by [visiting the project on GitHub](https://github.com/jekyll/jekyll).


### PR DESCRIPTION
Jekyll has moved from mojombo/jekyll to jekyll/jekyll. GitHub redirects
everybody automatically for us but let's point at the canonical
location for safety.

Thanks! :heart:
