### PR TITLE
add permalink to 404

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: "404: Page not found"
+permalink: 404.html
 ---
 
 <div class="page">


### PR DESCRIPTION
Add permalink to the front-matter. Github Pages will only show custom 404s when they are served from the root of a Pages domain, but using pretty permalinks serves the page from /404/index.html, so this declares the 404 should be served directly from the root.
