### PR TITLE
Add a "linkpost" format

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,3 +22,6 @@ version:          1.0.0
 
 github:
   repo:           https://github.com/poole/poole
+
+linkpost:
+  symbol:         '&rarr;'

--- a/_layouts/linkpost.html
+++ b/_layouts/linkpost.html
@@ -1,0 +1,27 @@
+---
+layout: default
+---
+
+<div class="post">
+  <h1 class="post-title">
+    <a href="{{ page.link }}">{{ page.title }} {{ site.linkpost.symbol }}</a>
+  </h1>
+  <span class="post-date">{{ page.date | date_to_string }}</span>
+  {{ content }}
+</div>
+
+<div class="related">
+  <h2>Related Posts</h2>
+  <ul class="related-posts">
+    {% for post in site.related_posts limit:3 %}
+      <li>
+        <h3>
+          <a href="{{ post.url }}">
+            {{ post.title }}
+            <small>{{ post.date | date_to_string }}</small>
+          </a>
+        </h3>
+      </li>
+    {% endfor %}
+  </ul>
+</div>

--- a/_posts/2013-12-30-linkpost.md
+++ b/_posts/2013-12-30-linkpost.md
@@ -1,0 +1,9 @@
+---
+layout: linkpost
+title: Example Linkpost
+link: http://distilledhype.net
+---
+
+> A quote from the site.
+
+Some context or an opinion.

--- a/index.html
+++ b/index.html
@@ -6,6 +6,21 @@ title: Home
 <div class="posts">
   {% for post in paginator.posts %}
   <div class="post">
+
+    {% if post.link %}
+
+    <h1 class="post-title">
+      <a href="{{ post.link }}">
+        {{ post.title }} {{ site.linkpost.symbol }}
+      </a>
+    </h1>
+
+    <span class="post-date">
+      <a href="{{ post.url }}">{{ post.date | date_to_string }}</a>
+    </span>
+
+    {% else %}
+
     <h1 class="post-title">
       <a href="{{ post.url }}">
         {{ post.title }}
@@ -13,6 +28,8 @@ title: Home
     </h1>
 
     <span class="post-date">{{ post.date | date_to_string }}</span>
+
+    {% endif %}
 
     {{ post.content }}
   </div>

--- a/public/css/poole.css
+++ b/public/css/poole.css
@@ -342,7 +342,7 @@ tbody tr:nth-child(odd) th {
 }
 
 /* Meta data line below post title */
-.post-date {
+.post-date, .post-date a {
   display: block;
   margin-top: -.5rem;
   margin-bottom: 1rem;


### PR DESCRIPTION
Hey @mdo, I love your Poole setup but I was missing the ability to add link posts.
So here is a set of changes and additions I am proposing:

Addition to _config.yml:
  Add the ability to set a link post symbol like "→".

New file: _layouts/linkpost.html
  Takes care of linking the title to the link provided in the meta data and
  inserts the link post symbol.

Addition to index.html:
  Sets the correct link in the title for link posts and sets the post url to
  the post date in the homepage list of posts.

Addition to pubic/css/poole.css:
  Reset the look for the post date for when it is linking to the post page for
  link posts.

New example link post: _posts/2013-12-30-linkpost.md
  An example linkpost.
