### PR TITLE
'pygments' option now called 'highlighter'

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 # Dependencies
 markdown:         redcarpet
-pygments:         true
+highlighter:      rouge
 
 # Permalinks
 permalink:        pretty


### PR DESCRIPTION
Since pygments is not the only option you can use to do code highlighting anymore that option is now called `highlighter`. You can either give it the value `pygments` or the value `rouge`. 

I'd recommend using `rouge` (https://github.com/jneen/rouge) because it is written in Ruby and spares you the pain of installing Python on your system just to do code highlighting in Jekyll.
