### PR TITLE
Fix #42

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 # Dependencies
 markdown:         redcarpet
-pygments:         true
+highlighter:      pygments
 
 # Permalinks
 permalink:        pretty


### PR DESCRIPTION
The "pygments" option is deprecated, and `jekyll build` prints a warning. This eliminates the warning.
