### PR TITLE
fix atom media type

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -22,5 +22,5 @@
   <link rel="shortcut icon" href="{{ site.baseurl }}public/favicon.ico">
 
   <!-- RSS -->
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="{{ site.baseurl }}atom.xml">
+  <link rel="alternate" type="application/atom+xml" title="RSS" href="{{ site.baseurl }}atom.xml">
 </head>


### PR DESCRIPTION
According to [RFC 4287 section 2](http://tools.ietf.org/html/rfc4287#section-2) the correct media type is `application/atom+xml`.
