### PR TITLE
Use Jekyll's default Markdown parser and highligher

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,3 @@
-# Dependencies
-markdown:         redcarpet
-highlighter:      pygments
-
 # Permalinks
 permalink:        pretty
 relative_permalinks: true


### PR DESCRIPTION
With the current version of Jekyll (2.4.0), this changes the Markdown parser to Kramdown.

If you're curious about the differences in the generated site, [here's a diff](https://gist.github.com/nicolasmccurdy/44dac380596785571d2d). Note that most of the changes involve smart quotes and other typography features.

Fixes #56.
## Advantages
- default markdown parser for Jekyll, so it follows the conventions of other Jekyll projects
- smart quotes and other typography features
- support for extra markdown features like tables
