### PR TITLE
Fixed permalinks on related posts

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -14,7 +14,7 @@ layout: default
     {% for post in site.related_posts limit:3 %}
       <li>
         <h3>
-          <a href="{{ site.baseurl }}/{{ post.url }}">
+          <a href="{{ site.baseurl }}{{ post.url }}">
             {{ post.title }}
             <small><time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date_to_string }}</time></small>
           </a>


### PR DESCRIPTION
Following #86 and then #65 I found that there still was a "/" between {{ site.baseurl }} and {{ post.url }}. By deleting it permalinks to related posts work properly now.