### PR TITLE
Include Neue Haas Grotesk in font stack

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -15,7 +15,7 @@ body {
 }
 
 html {
-  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-family: "Helvetica Neue", Helvetica, "Neue Haas Grotesk Text Pro", Arial, sans-serif;
   font-size: 16px;
   line-height: 1.5;
 


### PR DESCRIPTION
Starting from Windows 10, Neue Haas Grotesk [will be included as one of the default fonts](http://www.frederickding.com/posts/2015/07/new-fonts-in-windows-10-082445/) on Windows. It is basically [a digital reconstruction of Helvetica in its original form](http://www.fontbureau.com/nhg/).

This update will let Windows use NHG as the default font to avoid using the usual Arial as an alternative.