### PR TITLE
Fix validation for id tag

### DIFF
--- a/atom.xml
+++ b/atom.xml
@@ -9,7 +9,7 @@ layout: null
  <link href="{{ site.url }}{{ site.baseurl }}/atom.xml" rel="self"/>
  <link href="{{ site.url }}{{ site.baseurl }}/"/>
  <updated>{{ site.time | date_to_xmlschema }}</updated>
- <id>{{ site.url }}</id>
+ <id>{{ site.url }}/</id>
  <author>
    <name>{{ site.author.name }}</name>
    <email>{{ site.author.email }}</email>


### PR DESCRIPTION
The first id tag is missing it's trailing slash to pass validation.
