### PR TITLE
XML escaped post title in sitemap

### DIFF
--- a/atom.xml
+++ b/atom.xml
@@ -17,7 +17,7 @@ layout: null
 
  {% for post in site.posts %}
  <entry>
-   <title>{{ post.title }}</title>
+   <title>{{ post.title | xml_escape }}</title>
    <link href="{{ site.url }}{{ site.baseurl }}{{ post.url }}"/>
    <updated>{{ post.date | date_to_xmlschema }}</updated>
    <id>{{ site.url }}{{ post.id }}</id>


### PR DESCRIPTION
XML escaped post title in sitemap to avoid errors caused by XML special characters.