### PR TITLE
Jekyll 3 code highlighting with figure tag

### DIFF
--- a/_sass/_code.scss
+++ b/_sass/_code.scss
@@ -28,9 +28,10 @@ pre code {
   background-color: transparent;
 }
 
-// Pygments via Jekyll
+// Rouge via Jekyll
 .highlight {
   padding: 1rem;
+  margin: 0;
   margin-bottom: 1rem;
   font-size: .8rem;
   line-height: 1.4;


### PR DESCRIPTION
Jekyll 3 now uses the HTML5 `figure` tag for code highlighting.
This PR removes the additional margin that the tag renders by default (at least in chrome).
