### PR TITLE
Use Consolas instead of Courier New

### DIFF
--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -26,5 +26,5 @@ $border-color: #e5e5e5;
 $large-breakpoint: 38em;
 $large-font-size: 20px;
 
-$code-font-family: Menlo, Monaco, "Courier New", monospace;
+$code-font-family: Menlo, Monaco, "Consolas", "Courier New", monospace;
 $code-color: #bf616a;


### PR DESCRIPTION
Consolas is the new monospace font for Windows, introduced back in Windows Vista.
