### PR TITLE
Fix spelling mistake in Example Content post

### DIFF
--- a/_posts/2016-01-02-example-content.md
+++ b/_posts/2016-01-02-example-content.md
@@ -20,7 +20,7 @@ HTML defines a long list of available inline tags, a complete list of which can 
 
 - **To bold text**, use `<strong>`.
 - *To italicize text*, use `<em>`.
-- Abbreviations, like <abbr title="HyperText Markup Langage">HTML</abbr> should use `<abbr>`, with an optional `title` attribute for the full phrase.
+- Abbreviations, like <abbr title="HyperText Markup Language">HTML</abbr> should use `<abbr>`, with an optional `title` attribute for the full phrase.
 - Citations, like <cite>&mdash; Mark otto</cite>, should use `<cite>`.
 - <del>Deleted</del> text should use `<del>` and <ins>inserted</ins> text should use `<ins>`.
 - Superscript <sup>text</sup> uses `<sup>` and subscript <sub>text</sub> uses `<sub>`.


### PR DESCRIPTION
Just correcting the spelling of 'Language' in HTML abbreviation, no biggy.
