### PR TITLE
Nitrous.io Quickstart button

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Individual theme feedback and bug reports should be submitted to the theme's ind
 ## Contents
 
 - [Usage](#usage)
+- [Nitrous Quickstart](#nitrous-quickstart)
 - [Options](#options)
   - [Rems, `font-size`, and scaling](#rems-font-size-and-scaling)
 - [Development](#development)
@@ -70,6 +71,16 @@ If you host your code on GitHub, you can use [GitHub Pages](https://pages.github
 3. Done! Head to your GitHub Pages URL or custom domain.
 
 No matter your production or hosting setup, be sure to verify the `baseurl` option file and `CNAME` settings. Not applying this correctly can mean broken styles on your site.
+
+## Nitrous Quickstart
+
+Create a free development environment for this Poole project in the cloud on [Nitrous.io](https://www.nitrous.io) by clicking the button below.
+
+<a href="https://www.nitrous.io/quickstart">
+  <img src="https://nitrous-image-icons.s3.amazonaws.com/quickstart.png" alt="Nitrous Quickstart" width=142 height=34>
+</a>
+
+In the IDE, start Poole via `Run > Start Poole` and access your site via `Preview > 3000`.
 
 ## Options
 

--- a/README.nitrous.md
+++ b/README.nitrous.md
@@ -1,0 +1,13 @@
+# Setup
+
+Welcome to your Poole project on Nitrous.
+
+## Running the Jekyll server:
+
+In the [Nitrous IDE](https://community.nitrous.io/docs/ide-overview), start Poole via "Run > Start Poole"
+
+Now you've got a development server running and can see the output in the Nitrous terminal window. You can open up a new shell or utilize [tmux](https://community.nitrous.io/docs/tmux) to open new shells to run other commands.
+
+## Preview the app
+
+In the Nitrous IDE, open the "Preview" menu and click "Port 3000".

--- a/nitrous.json
+++ b/nitrous.json
@@ -1,0 +1,10 @@
+{
+  "template": "jekyll",
+  "ports": [3000],
+  "name": "Poole",
+  "description": "The Jekyll Butler.",
+  "scripts": {
+    "post-create": "gem install jekyll-paginate && gem install jekyll-gist",
+    "Start Poole": "cd ~/code/poole && jekyll serve --host 0.0.0.0 --port 3000"
+  }
+}


### PR DESCRIPTION
Added Nitrous Quickstart files so anyone can quickly spin up a free, cloud dev environment to start using this repo. Clicking the Quickstart button will automatically clone this repo and will install and configure any required packages