### PR TITLE
Fix contrast between bold text in blockquotes

### DIFF
--- a/_sass/_type.scss
+++ b/_sass/_type.scss
@@ -87,6 +87,9 @@ blockquote {
   }
 }
 
+blockquote strong {
+  color: #515151;
+}
 
 // Markdown footnotes
 //


### PR DESCRIPTION
See issue #134 "Contrast issue with `<strong>` text inside `<blockquote>`"

This pull request fixes this issue by making bold text inside blockquotes the same color as normal text. That way, there is still a contrast between bold text inside blockquotes, but the contrast is not as extreme.