### PR TITLE
Removed default code block margins

### DIFF
--- a/_sass/_code.scss
+++ b/_sass/_code.scss
@@ -16,6 +16,10 @@ code {
   border-radius: 3px;
 }
 
+figure {
+  margin: 0;
+}
+
 pre {
   margin-top: 0;
   margin-bottom: 1rem;


### PR DESCRIPTION
In most browsers, a User Agent stylesheet is defined that adds margins to either side of a `figure` (used to render code blocks in the example post). Here's what the stylesheet looks like in Chrome and Safari:

```
figure {
    display: block;
    -webkit-margin-before: 1em;
    -webkit-margin-after: 1em;
    -webkit-margin-start: 40px;
    -webkit-margin-end: 40px;
}
```

After first I thought this was a stylistic decision, but then realized this property was not set, so this styling was probably unintentional.

This change also makes code blocks behave more like blockquotes, which I think is desirable.
