### PR TITLE
'gems:' is deprecated in favour of 'plugins:'

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,6 +27,6 @@ github:
   repo:              https://github.com/poole/poole
 
 # Gems
-gems:
+plugins:
   - jekyll-paginate
   - jekyll-gist


### PR DESCRIPTION
See https://github.com/jekyll/jekyll/pull/5130