### PR TITLE
Update Jekyll Docs link to map to current url

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ $ gem install jekyll jekyll-gist jekyll-sitemap jekyll-seo-tag
 
 **Windows users:** Windows users have a bit more work to do, but luckily [@juthilo](https://github.com/juthilo) has your back with his [Run Jekyll on Windows](https://github.com/juthilo/run-jekyll-on-windows) guide.
 
-**Need syntax highlighting?** Poole includes support for Pygments or Rouge, so install your gem of choice to make use of the built-in styling. Read more about this [in the Jekyll docs](http://jekyllrb.com/docs/templates/#code_snippet_highlighting).
+**Need syntax highlighting?** Poole includes support for Pygments or Rouge, so install your gem of choice to make use of the built-in styling. Read more about this in the [Jekyll docs](https://jekyllrb.com/docs/liquid/tags/#code-snippet-highlighting).
 
 ### 2a. Quick start
 


### PR DESCRIPTION
https://jekyllrb.com/docs/liquid/tags/#code-snippet-highlighting is the current page that references code-snippet-highlighting