### PR TITLE
Fix the displaying bug of pagination on the small screen

### DIFF
--- a/_sass/_pagination.scss
+++ b/_sass/_pagination.scss
@@ -4,8 +4,6 @@
 // there are no more previous or next posts to show.
 
 .pagination {
-  display: flex;
-  margin: 0 -1.5rem var(--spacer);
   color: var(--gray-500);
   text-align: center;
 }
@@ -31,6 +29,7 @@ a.pagination-item:hover {
 @media (min-width: 30em) {
   .pagination {
     margin: var(--spacer-3) 0;
+    height: calc(var(--body-font-size) * var(--body-line-height) + var(--spacer) * 2);
   }
 
   .pagination-item {


### PR DESCRIPTION
Related issue: #190 

Pagination on the small screen:

<img width="461" alt="Screenshot 2020-10-10 at 8 11 11 PM" src="https://user-images.githubusercontent.com/72621374/95654766-d08c6980-0b34-11eb-9c18-b4d984eb785c.png">

Pagination on the large screen:

<img width="1100" alt="Screenshot 2020-10-10 at 8 11 27 PM" src="https://user-images.githubusercontent.com/72621374/95654770-d8e4a480-0b34-11eb-83d2-9be0dc373f61.png">
