### PR TITLE
Add workflow to publish gem

### DIFF
--- a/.github/workflows/publish-gem.yml
+++ b/.github/workflows/publish-gem.yml
@@ -1,0 +1,31 @@
+name: Publish Gem
+
+on:
+  push:
+    tags:
+      - '*'
+jobs:
+  build:
+    name: Build + Publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby 3.0
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 3.0.x
+
+    - name: Publish to RubyGems
+      run: |
+        mkdir -p $HOME/.gem
+        touch $HOME/.gem/credentials
+        chmod 0600 $HOME/.gem/credentials
+        printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+        gem build *.gemspec
+        gem push *.gem
+      env:
+        GEM_HOST_API_KEY: "${{secrets.RUBYGEMS_AUTH_TOKEN}}"


### PR DESCRIPTION
https://rubygems.org/gems/poole-for-jekyll-test - example of the publish.

This PR adds a Github workflow to automatically publish the poole gem on `git push --tags`.

This PR requires some prework before being able to succeed:

1. Create a Rubygems API key with the following scopes
<img width="246" alt="image" src="https://user-images.githubusercontent.com/44616801/184397088-3b1a22cb-1afc-4913-9686-2b5db0483c9a.png">

2. Create a repository secret `RUBYGEMS_AUTH_TOKEN` with the value of the API key generated in step 1.